### PR TITLE
chore(ci): group all github-actions dependabot updates into one pr

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,6 +45,11 @@ updates:
     schedule:
       interval: 'weekly'
       day: 'monday'
+    groups:
+      # Group all Actions updates into one PR
+      github-actions:
+        patterns:
+          - '*'
     commit-message:
       # github-actions has no dev/prod distinction so include: scope always
       # produces deps. Hardcode deps-dev since Actions are CI tooling only.


### PR DESCRIPTION
## Summary

- Groups all GitHub Actions Dependabot updates into a single PR per week instead of one PR per action
- The existing open PRs (#64, #65, #66, #67) are stranded individuals from before this config existed and will need to be closed manually — future runs will produce one grouped PR

## Test plan

- [ ] Close the existing individual Actions Dependabot PRs and confirm the next Monday run produces a single grouped PR