### PR TITLE
chore(build): resolve lint and knip violations surfaced by dependency bumps

### DIFF
--- a/src/telemetry/TelemetryClient.test.ts
+++ b/src/telemetry/TelemetryClient.test.ts
@@ -232,7 +232,7 @@ describe('Telemetry', () => {
       expect(mockDetectEnvironment).toHaveBeenCalled();
 
       // @ts-expect-error accessing private for test
-      const eventQueue: readonly AugmentedTelemetryEvent[] = instance.eventQueue as AugmentedTelemetryEvent;
+      const eventQueue: readonly AugmentedTelemetryEvent[] = instance.eventQueue;
       const event: AugmentedTelemetryEvent = eventQueue[0];
       expect(event.properties).toEqual(
         expect.objectContaining({

--- a/src/telemetry/telemetryTypes.ts
+++ b/src/telemetry/telemetryTypes.ts
@@ -19,7 +19,7 @@ import { Environment, UnvalidatedCLIOptions } from '../types/types.js';
  * System metadata included with all events.
  * Used for aggregating usage patterns.
  */
-export interface SystemContext {
+interface SystemContext {
   /** Node.js version running CLI */
   readonly node_version: string;
   /** CLI package version */


### PR DESCRIPTION
`main` is currently red. The all-minor-patch Dependabot group (#113) upgraded `typescript-eslint` and `knip`, and the newer versions flag two pre-existing redundancies that now fail `npm run validate` on every branch:

- `@typescript-eslint/no-unnecessary-type-assertion` — a no-op `as AugmentedTelemetryEvent` cast on an array-typed variable in a telemetry test.
- `knip` (6.5 → 6.15) — `SystemContext` was exported but is only used inside its own module.

Both are removed: the dead cast, and the unnecessary `export`. No runtime or published-artifact change — this is lint/type hygiene that the upgraded tooling started enforcing. #113's auto-merge landed despite the matrix `Test` jobs failing, which is why this reached `main`; worth tightening branch protection separately so the matrix jobs are required.

## Test plan

- [x] `npm run validate` passes (eslint, 446 tests, dependency-cruiser, knip all green) against the post-#113 dependency set
